### PR TITLE
Changing write_point call to wrap data inside of values key.

### DIFF
--- a/lib/chef-handler-influxdb.rb
+++ b/lib/chef-handler-influxdb.rb
@@ -70,8 +70,7 @@ class ChefInfluxDB < Chef::Handler
 
     def report
       Chef::Log.info 'Exporting Chef run data to InfluxDB'
-      client.write_point(@series, generate_data)
+      client.write_point(@series, {values: generate_data})
     end
 
 end
-


### PR DESCRIPTION
  Needed to work with newer releases of the influxdb gem.
